### PR TITLE
Add container badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
+[![Docker Repository on Quay](https://quay.io/repository/galaxy/coastal-source-headless/status "Docker Repository on Quay")](https://quay.io/repository/galaxy/coastal-source-headless)
+
 # docker-coastal-source
 Docker container for Sea Observations Utility for Reprocessing, Calibration and Evaluation (SOURCE)


### PR DESCRIPTION
No clue why those badges always show None. But the container is available.

